### PR TITLE
Fix setup transactions while processing multi packet transactions

### DIFF
--- a/Drivers/STM32F_FS/usbd_drv_stm32f_fs.c
+++ b/Drivers/STM32F_FS/usbd_drv_stm32f_fs.c
@@ -2180,9 +2180,6 @@ static  void  STM32_RxFIFO_Rd (USBD_DRV  *p_drv)
                        ctl_reg |= STM32F_FS_DxEPCTLx_BIT_CNAK | STM32F_FS_DxEPCTLx_BIT_EPENA;
 
                        p_reg->DOEP[ep_log_nbr].CTLx          = ctl_reg;
-
-                                                                /* Clear output interrupt since more data is expected   */
-                       DEF_BIT_CLR(p_reg->GINTMSK, STM32F_FS_GINTMSK_BIT_OEPINT);
                      }
                  }
                  if (p_drv_data->EP_AppBufBlk[ep_phy_nbr] == 0) {


### PR DESCRIPTION
### Summary

This pull request fixes an issue I introduced with #2. I noticed that while a multi-packet transfer, setup transactions where having issues.

### Details

As mentioned above, this issues is observed when receiving setup packets and processing audio out with multiple packets. I noticed that #2 introduced a change in `STM32_RxFIFO_Rd` that impacts other endpoints, which shouldn't be the needed to my opinion. This change removes that usage. I cannot remember why I thought I needed to clear the output interrupt, but my testing showed that this is not necessary.

### Testing

To validate this change I ran this code on our target and processed out data while also receiving setup packets, this can be easily done connected to a laptop, streaming audio and changing volume continuously. Prior to this change, the driver/audio app would hang on trying to process setup packets, with this change all the setup transactions go through (confirmed on beagle capture).
Let me know if you want me to run more testing.