### PR TITLE
Set AudioStreaming interface name on default interface too.

### DIFF
--- a/Class/Audio/usbd_audio.c
+++ b/Class/Audio/usbd_audio.c
@@ -2552,7 +2552,7 @@ void  USBD_Audio_AS_IF_Add (       CPU_INT08U                class_nbr,
                                  USBD_CLASS_CODE_AUDIO,
                                  USBD_AUDIO_SUBCLASS_AUDIO_STREAMING,
                                  0u,
-                                "0-Bandwidth AudioStreaming Interface",
+                                 p_as_cfg_name,
                                  p_err);
     if (*p_err != USBD_ERR_NONE) {
         return;


### PR DESCRIPTION
The audio interface name is what's visible to the user in most OSs, so having it be something more descriptive than "0-Bandwidth AudioStreaming Interface" is desirable. As we already have an app-supplied interface name available here I changed the function to use that instead.